### PR TITLE
de: add `from_*` methods

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,12 @@ impl Display for Error {
     }
 }
 
+impl From<super::de::Error> for Error {
+    fn from(e: super::de::Error) -> Self {
+        Error::Custom(e.to_string())
+    }
+}
+
 impl ::std::error::Error for Error {
     fn description(&self) -> &str {
         "INI serialization error"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,42 @@ extern crate void;
 extern crate serde;
 
 pub mod de;
-pub mod ser;
-
+pub mod error;
 pub mod parse;
+pub mod ser;
 pub mod write;
 
 pub use de::Deserializer;
 pub use ser::Serializer;
 pub use parse::{Parser, Item};
 pub use write::{Writer, LineEnding};
+
+use error::*;
+
+/// Deserialize an instance of type `T` from a string of INI text.
+pub fn from_str<'a, T>(s: &'a str) -> Result<T>
+    where
+    T: serde::Deserialize<'a>,
+{
+    let mut de = Deserializer::new(parse::Parser::from_str(s.as_ref()));
+    let value = serde::Deserialize::deserialize(&mut de)?;
+
+    // Make sure the whole stream has been consumed.
+    de.end()?;
+    Ok(value)
+}
+
+/// Deserialize an instance of type `T` from a buffered IO stream of INI.
+pub fn from_bufread<'a, R, T>(reader: R) -> Result<T>
+    where
+    R: std::io::BufRead,
+    T: serde::Deserialize<'a>,
+{
+    let mut de = Deserializer::new(parse::Parser::from_bufread(reader));
+    let value = serde::Deserialize::deserialize(&mut de)?;
+
+    // Make sure the whole stream has been consumed.
+    de.end()?;
+    Ok(value)
+
+}

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -49,9 +49,21 @@ fn expected() -> TestModel {
 
 #[test]
 fn smoke_de() {
-    assert_eq!(expected(), TestModel::deserialize(&mut Deserializer::new(Parser::from_str(TEST_INPUT))).unwrap());
-
+    // Parser
     assert_eq!(expected(), TestModel::deserialize(&mut Deserializer::new(Parser::from_read(TEST_INPUT.as_bytes()))).unwrap());
+    assert_eq!(expected(), TestModel::deserialize(&mut Deserializer::new(Parser::from_str(&TEST_INPUT))).unwrap());
+
+    // Deserializer
+    let bufrd = std::io::BufReader::new(TEST_INPUT.as_bytes());
+    assert_eq!(expected(), TestModel::deserialize(&mut Deserializer::from_bufread(bufrd)).unwrap());
+    assert_eq!(expected(), TestModel::deserialize(&mut Deserializer::from_str(&TEST_INPUT)).unwrap());
+
+    // Static methods
+    let bufrd = std::io::BufReader::new(TEST_INPUT.as_bytes());
+    let de_bufrd: TestModel = serde_ini::from_bufread(bufrd).unwrap();
+    let de_str: TestModel = serde_ini::from_str(&TEST_INPUT).unwrap();
+    assert_eq!(expected(), de_bufrd);
+    assert_eq!(expected(), de_str);
 }
 
 #[test]


### PR DESCRIPTION
This adds `from_str` and `from_bufread` methods to Deserializer.
It also adds some basic integration testing.