### PR TITLE
Ignore whitespace when parsing key/value pairs

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -135,8 +135,8 @@ impl<T> Parser<T> {
             if let Some(key) = line.next() {
                 if let Some(value) = line.next() {
                     Ok(Some(Item::Value {
-                        key: key.into(),
-                        value: value.into(),
+                        key: key.trim().into(),
+                        value: value.trim().into(),
                     }))
                 } else if key.is_empty() {
                     Ok(Some(Item::Empty))

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -10,6 +10,7 @@ use serde_ini::{Deserializer, Parser};
 struct TestModel {
     key1: String,
     key2: u32,
+    key3: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     map1: Option<Box<TestModel>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -20,21 +21,25 @@ const TEST_INPUT: &'static str = "
 ; Ignored comment
 key1=value1
 key2=255
+ key3 = value3
 
 [map1]
 key2=256
 key1=value2
+key3=
 
 # We also treat hash as a comment character.
 [map2]
 key1=value3
 key2=257
+key3=
 ";
 
 fn expected() -> TestModel {
     TestModel {
         key1: "value1".into(),
         key2: 255,
+        key3: "value3".into(),
         map1: Some(Box::new(TestModel {
             key1: "value2".into(),
             key2: 256,
@@ -50,6 +55,7 @@ fn expected() -> TestModel {
 
 #[test]
 fn smoke_de() {
+
     // Parser
     assert_eq!(expected(), TestModel::deserialize(&mut Deserializer::new(Parser::from_bufread(TEST_INPUT.as_bytes()))).unwrap());
     assert_eq!(expected(), TestModel::deserialize(&mut Deserializer::new(Parser::from_read(TEST_INPUT.as_bytes()))).unwrap());
@@ -70,7 +76,7 @@ fn smoke_de() {
 fn smoke_en() {
     let model = expected();
 
-    let mut data = serde_ini::to_vec(&model).unwrap();
+    let data = serde_ini::to_vec(&model).unwrap();
 
     assert_eq!(model, serde_ini::from_read::<_, TestModel>(&data[..]).unwrap());
 }


### PR DESCRIPTION
I ran into this when trying to parse git config files. I've opted to just ignore surrounding whitespace on key/value pairs. I guess it would be possible to add a setting to control this behaviour as it's technically backwards incompatible. Thoughts?