### PR TITLE
Deserialize to sequence of enum types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display};
 
 #[derive(Debug, Clone)]
 pub enum Error {
-    Custom(String)
+    Custom(String),
 }
 
 impl Display for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub mod parse;
 pub mod ser;
 pub mod write;
 
-pub use de::{Deserializer, from_str, from_bufread, from_read};
-pub use ser::{Serializer, to_string, to_vec, to_writer};
-pub use parse::{Parser, Item};
-pub use write::{Writer, LineEnding};
+pub use de::{from_bufread, from_read, from_str, Deserializer};
+pub use parse::{Item, Parser};
+pub use ser::{to_string, to_vec, to_writer, Serializer};
+pub use write::{LineEnding, Writer};

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,20 +1,13 @@
-use std::{io, fmt, error, str};
 use result::prelude::*;
+use std::{error, fmt, io, str};
 use void::Void;
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub enum Item {
     Empty,
-    Section {
-        name: String
-    },
-    Value {
-        key: String,
-        value: String,
-    },
-    Comment {
-        text: String
-    },
+    Section { name: String },
+    Value { key: String, value: String },
+    Comment { text: String },
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
@@ -77,9 +70,7 @@ pub struct Parser<T> {
 
 impl<T> Parser<T> {
     pub fn new(input: T) -> Self {
-        Parser {
-            input: input,
-        }
+        Parser { input: input }
     }
 
     pub fn into_inner(self) -> T {
@@ -119,17 +110,13 @@ impl<T> Parser<T> {
                 if line.contains(']') {
                     Err(Error::Syntax(SyntaxError::SectionName))
                 } else {
-                    Ok(Some(Item::Section {
-                        name: line.into(),
-                    }))
+                    Ok(Some(Item::Section { name: line.into() }))
                 }
             } else {
                 Err(Error::Syntax(SyntaxError::SectionNotClosed))
             }
         } else if line.starts_with(';') || line.starts_with('#') {
-            Ok(Some(Item::Comment {
-                text: line.into(),
-            }))
+            Ok(Some(Item::Comment { text: line.into() }))
         } else {
             let mut line = line.splitn(2, '=');
             if let Some(key) = line.next() {
@@ -150,17 +137,21 @@ impl<T> Parser<T> {
     }
 }
 
-impl<E, S: AsRef<str>, T: Iterator<Item=Result<S, E>>> Iterator for Parser<T> {
+impl<E, S: AsRef<str>, T: Iterator<Item = Result<S, E>>> Iterator for Parser<T> {
     type Item = Result<Item, Error<E>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.input.next_invert().map_err(Error::Inner).and_then(|l| Self::parse_next(l)).invert()
+        self.input
+            .next_invert()
+            .map_err(Error::Inner)
+            .and_then(|l| Self::parse_next(l))
+            .invert()
     }
 }
 
 pub struct OkIter<I>(pub I);
 
-impl<T, I: Iterator<Item=T>> Iterator for OkIter<I> {
+impl<T, I: Iterator<Item = T>> Iterator for OkIter<I> {
     type Item = Result<T, Void>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,6 +1,6 @@
 use parse::Item;
-use std::io::{self, Write};
 use std::fmt;
+use std::io::{self, Write};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum LineEnding {
@@ -16,10 +16,14 @@ impl Default for LineEnding {
 
 impl fmt::Display for LineEnding {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", match *self {
-            LineEnding::Linefeed => "\n",
-            LineEnding::CrLf => "\r\n",
-        })
+        write!(
+            f,
+            "{}",
+            match *self {
+                LineEnding::Linefeed => "\n",
+                LineEnding::CrLf => "\r\n",
+            }
+        )
     }
 }
 
@@ -46,7 +50,9 @@ impl<W: Write> Writer<W> {
     pub fn write(&mut self, item: &Item) -> io::Result<()> {
         match *item {
             Item::Section { ref name } => write!(&mut self.write, "[{}]{}", name, self.line_ending),
-            Item::Value { ref key, ref value } => write!(&mut self.write, "{}={}{}", key, value, self.line_ending),
+            Item::Value { ref key, ref value } => {
+                write!(&mut self.write, "{}={}{}", key, value, self.line_ending)
+            }
             Item::Comment { ref text } => write!(&mut self.write, ";{}{}", text, self.line_ending),
             Item::Empty => write!(&mut self.write, "{}", self.line_ending),
         }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -43,33 +43,65 @@ fn expected() -> TestModel {
         map1: Some(Box::new(TestModel {
             key1: "value2".into(),
             key2: 256,
-            .. Default::default()
+            ..Default::default()
         })),
         map2: Some(Box::new(TestModel {
             key1: "value3".into(),
             key2: 257,
-            .. Default::default()
+            ..Default::default()
         })),
     }
 }
 
 #[test]
 fn smoke_de() {
-
     // Parser
-    assert_eq!(expected(), TestModel::deserialize(&mut Deserializer::new(Parser::from_bufread(TEST_INPUT.as_bytes()))).unwrap());
-    assert_eq!(expected(), TestModel::deserialize(&mut Deserializer::new(Parser::from_read(TEST_INPUT.as_bytes()))).unwrap());
-    assert_eq!(expected(), TestModel::deserialize(&mut Deserializer::new(Parser::from_str(TEST_INPUT))).unwrap());
+    assert_eq!(
+        expected(),
+        TestModel::deserialize(&mut Deserializer::new(Parser::from_bufread(
+            TEST_INPUT.as_bytes()
+        )))
+        .unwrap()
+    );
+    assert_eq!(
+        expected(),
+        TestModel::deserialize(&mut Deserializer::new(Parser::from_read(
+            TEST_INPUT.as_bytes()
+        )))
+        .unwrap()
+    );
+    assert_eq!(
+        expected(),
+        TestModel::deserialize(&mut Deserializer::new(Parser::from_str(TEST_INPUT))).unwrap()
+    );
 
     // Deserializer
-    assert_eq!(expected(), TestModel::deserialize(&mut Deserializer::from_bufread(TEST_INPUT.as_bytes())).unwrap());
-    assert_eq!(expected(), TestModel::deserialize(&mut Deserializer::from_read(TEST_INPUT.as_bytes())).unwrap());
-    assert_eq!(expected(), TestModel::deserialize(&mut Deserializer::from_str(TEST_INPUT)).unwrap());
+    assert_eq!(
+        expected(),
+        TestModel::deserialize(&mut Deserializer::from_bufread(TEST_INPUT.as_bytes())).unwrap()
+    );
+    assert_eq!(
+        expected(),
+        TestModel::deserialize(&mut Deserializer::from_read(TEST_INPUT.as_bytes())).unwrap()
+    );
+    assert_eq!(
+        expected(),
+        TestModel::deserialize(&mut Deserializer::from_str(TEST_INPUT)).unwrap()
+    );
 
     // Static methods
-    assert_eq!(expected(), serde_ini::from_bufread::<_, TestModel>(TEST_INPUT.as_bytes()).unwrap());
-    assert_eq!(expected(), serde_ini::from_read::<_, TestModel>(TEST_INPUT.as_bytes()).unwrap());
-    assert_eq!(expected(), serde_ini::from_str::<TestModel>(TEST_INPUT).unwrap());
+    assert_eq!(
+        expected(),
+        serde_ini::from_bufread::<_, TestModel>(TEST_INPUT.as_bytes()).unwrap()
+    );
+    assert_eq!(
+        expected(),
+        serde_ini::from_read::<_, TestModel>(TEST_INPUT.as_bytes()).unwrap()
+    );
+    assert_eq!(
+        expected(),
+        serde_ini::from_str::<TestModel>(TEST_INPUT).unwrap()
+    );
 }
 
 #[test]
@@ -78,5 +110,8 @@ fn smoke_en() {
 
     let data = serde_ini::to_vec(&model).unwrap();
 
-    assert_eq!(model, serde_ini::from_read::<_, TestModel>(&data[..]).unwrap());
+    assert_eq!(
+        model,
+        serde_ini::from_read::<_, TestModel>(&data[..]).unwrap()
+    );
 }


### PR DESCRIPTION
The patch deals with repeated top level sections. For example,

```ini
[person]
name = "Ana"

[person]
name = "Box"
```

It enables the deserialization into a sequence of enum types. The code below will work out of box.

```rust
#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
enum Person {
    pub name: String
}

let people: Vec<Person> = serde_ini::from_str(ini_text)?;
```