### PR TITLE
Support for serializing enum struct variants as sections

### DIFF
--- a/tests/enum_map_seq.rs
+++ b/tests/enum_map_seq.rs
@@ -3,42 +3,50 @@ extern crate serde_derive;
 extern crate serde;
 extern crate serde_ini;
 
+use std::collections::BTreeMap;
+
 use serde::Deserialize;
 use serde_ini::{Deserializer, Parser};
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Debug)]
 enum TestModel {
-    Person {
-        name: String,
-    }
+    Person(BTreeMap<String, String>),
 }
 
 const TEST_INPUT: &'static str = "
 [Person]
 name=Ana
+likes=pickles
 
 [Person]
-name=Box
+name=Fred
+dislikes=Ana
 ";
 
 fn expected() -> Vec<TestModel> {
+    let mut ana = BTreeMap::new();
+
+    ana.insert("name".into(), "Ana".into());
+    ana.insert("likes".into(), "pickles".into());
+
+    let mut fred = BTreeMap::new();
+
+    fred.insert("name".into(), "Fred".into());
+    fred.insert("dislikes".into(), "Ana".into());
+
     vec![
-        TestModel::Person {
-            name: "Ana".into(),
-        },
-        TestModel::Person {
-            name: "Box".into(),
-        },
+        TestModel::Person(ana),
+        TestModel::Person(fred),
     ]
 }
 
 #[test]
-fn enum_seq_de() {
+fn enum_map_seq_de() {
     assert_eq!(expected(), serde_ini::from_str::<Vec<TestModel>>(TEST_INPUT).unwrap());
 }
 
 #[test]
-fn enum_seq_en() {
+fn enum_map_seq_en() {
     let model = expected();
 
     let data = serde_ini::to_vec(&model).unwrap();


### PR DESCRIPTION
This should finally complete #19.

The commit is a bit long because I wanted to cover just about every conceivable way that someone might want to represent sections at the top level using either enum struct variants or newtype variants with maps/structs in them, and serde doesn't really help with repetitiveness for each implementation of `Serializer`.