### PR TITLE
Adds colon (:) as a value delimiter

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -131,7 +131,7 @@ impl<T> Parser<T> {
                 text: line.into(),
             }))
         } else {
-            let mut line = line.splitn(2, '=');
+            let mut line = line.splitn(2, |c| c == '=' || c == ':');
             if let Some(key) = line.next() {
                 if let Some(value) = line.next() {
                     Ok(Some(Item::Value {

--- a/tests/enum_seq.rs
+++ b/tests/enum_seq.rs
@@ -19,6 +19,9 @@ name=Ana
 
 [Person]
 name=Box
+
+[Person]
+name:Callie
 ";
 
 fn expected() -> Vec<TestModel> {
@@ -28,6 +31,9 @@ fn expected() -> Vec<TestModel> {
         },
         TestModel::Person {
             name: "Box".into(),
+        },
+        TestModel::Person {
+            name: "Callie".into(),
         },
     ]
 }


### PR DESCRIPTION
Colon (:) is described in [1] as a possible value delimiter Adds a simple deserialization test in enum_seq.rs

[1] https://en.wikipedia.org/wiki/INI_file#Name/value_delimiter